### PR TITLE
add Orb challenge

### DIFF
--- a/05 Orbs/.circleci/config.yml
+++ b/05 Orbs/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+orbs:
+  # Add Orb here
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      # Add step below to install Ruby version 2.3.8
+
+      
+      - run: ruby -v
+
+workflows:
+  run-jobs:
+    jobs:
+      - build

--- a/05 Orbs/README.md
+++ b/05 Orbs/README.md
@@ -1,0 +1,17 @@
+# Orbs
+
+**Description:**
+
+We have a config file that requires a specific Ruby version be installed, however the image we are using doesn't have Ruby, so the build fails. Utilizing the Ruby Orb (`circleci/ruby`) install Ruby version `2.3.8` so the build will be green.
+
+**Goals:**
+
+- Add the Ruby Orb to the config file
+- Install Ruby version `2.3.8` with Orb
+- Build should be green if Ruby installed properly
+
+**Help:**
+<details>
+  <summary>Spoiler warning</summary>
+  https://circleci.com/orbs/registry/orb/circleci/ruby#usage-examples
+</details>

--- a/05 Orbs/src/README.md
+++ b/05 Orbs/src/README.md
@@ -1,0 +1,3 @@
+# SRC
+
+Include any required files for the challenge here. The testee should be able to clone this repo and run this challenge as a standalone project.


### PR DESCRIPTION
### Why:
As new features are released we want to keep this project updated, this PR takes care of adding a challenge that covers the concept of using Orbs. It requires the trainee to set the Orb and invoke it with a parameter to get a passing build.

### What:
This adds an example `config.yml` file missing a few key items, and is currently failing. It also adds a `README.md` that contains information about the challenge. 

