### PR TITLE
Add cache challenge

### DIFF
--- a/06 Caching/.circleci/config.yml
+++ b/06 Caching/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:12.16
+    steps:
+      - checkout
+      # Uncomment below and set the key to point to the proper file
+      #- restore_cache:
+          #name: Restore Yarn Package Json Cache
+          #keys:            
+      - run:
+          name: Install Dependencies
+          command: yarn install --immutable
+      # Uncomment below and set the key to point to the proper file
+      #- save_cache:
+          #name: Save Yarn Package Json Cache
+          #key: 
+          #paths:
+            #- ~/.cache/yarn
+
+workflows:
+  cache-save-and-restore:
+    jobs:
+      - build

--- a/06 Caching/README.md
+++ b/06 Caching/README.md
@@ -1,0 +1,44 @@
+# Caching
+
+**Description:**
+
+We want to speed up our builds and we heard about this concept of "caching". We need to start storing a cache of our `package.json` so that it can be restored in subsequent builds.
+
+In addition we need to know what to do if we need to force a new save of the cache.
+
+**Goals:**
+
+- Uncomment out the `save_cache` and `restore_cache` steps
+- Update the `key` of each of those to point at the proper file
+- Push up a commit where you find it successfully saves the cache (should see something like this on the step):
+
+```
+Creating cache archive...
+Uploading cache archive...
+Stored Cache to yarn-packages-v1-qwa_N++0aXeaXlpPu1TzrRMKJU1V7n3NYN+0BxBVg20=
+  * /home/circleci/.cache/yarn
+```
+
+- Push another commit and confirm the cache is restored/used (should see something like this):
+
+```
+Found a cache from build 44 at yarn-packages-qwa_N++0aXeaXlpPu1TzrRMKJU1V7n3NYN+0BxBVg20=
+Size: 160 B
+Cached paths:
+  * /home/circleci/.cache/yarn
+
+Downloading cache archive...
+Validating cache...
+
+Unarchiving cache...
+```
+
+- Finally make the neccesary edits to the config to 'bust' or 'clear' the cache so it doesn't use the existing saved cache and instead stores a new one.
+
+**Help:**
+<details>
+  <summary>Spoiler warning</summary>
+  https://circleci.com/docs/2.0/caching/
+  https://circleci.com/docs/2.0/yarn/#caching
+  https://circleci.com/docs/2.0/caching/#clearing-cache
+</details>

--- a/06 Caching/package.json
+++ b/06 Caching/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "caching",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/06 Caching/src/README.md
+++ b/06 Caching/src/README.md
@@ -1,0 +1,3 @@
+# SRC
+
+Include any required files for the challenge here. The testee should be able to clone this repo and run this challenge as a standalone project.


### PR DESCRIPTION
### Why:
As new features are released we want to keep this project updated, this PR takes care of adding a challenge that covers the concept of using Caching. It requires the trainee to update the config to save and restore a cache. Then push a build that saves it, a build that uses the cache, and one that 'busts' the cache.

### What:
This adds an example config.yml file with some steps commented out -- they need to be uncommented and updated. It also adds a README.md that contains information about the challenge and a `package.json` file to be used in caching. 