### PR TITLE
Remove parameter "name" in build-tools/test-results

### DIFF
--- a/07 Test Summary/.circleci/config.yml
+++ b/07 Test Summary/.circleci/config.yml
@@ -1,13 +1,12 @@
 version: 2.1
 orbs:
-  build-tools: circleci/build-tools@2.2.0 # This is an orb. If you are not yet familiar with orbs, we will go over them soon. Orbs allow us to make our configs shorter by allowing us to "import" config in a similar way to a programming language's package manager.
+  build-tools: circleci/build-tools@2.9.1 # This is an orb. If you are not yet familiar with orbs, we will go over them soon. Orbs allow us to make our configs shorter by allowing us to "import" config in a similar way to a programming language's package manager.
 jobs:
   build:
     docker: 
       - image: circleci/node 
     steps:
       - build-tools/test-results:
-          name: Generating test results.
           data-dir: ~/project/results
           upload: true
 # Add below this line, do not modify above


### PR DESCRIPTION
https://circleci.com/developer/orbs/orb/circleci/build-tools?version=2.9.1#commands-test-results
Current version(or even 2.2.0) of build-tools/test-results does not define parameter "name"
This will cause syntax error