### PR TITLE
05 Orb: Update Ruby version

### DIFF
--- a/05 Orbs/.circleci/config.yml
+++ b/05 Orbs/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      # Add step below to install Ruby version 2.3.8
+      # Add step below to install Ruby version 2.6.3
 
       
       - run: ruby -v

--- a/05 Orbs/README.md
+++ b/05 Orbs/README.md
@@ -2,12 +2,12 @@
 
 **Description:**
 
-We have a config file that requires a specific Ruby version be installed, however the image we are using doesn't have Ruby, so the build fails. Utilizing the Ruby Orb (`circleci/ruby`) install Ruby version `2.3.8` so the build will be green.
+We have a config file that requires a specific Ruby version be installed, however the image we are using doesn't have Ruby, so the build fails. Utilizing the Ruby Orb (`circleci/ruby`) install Ruby version `2.6.3` so the build will be green.
 
 **Goals:**
 
 - Add the Ruby Orb to the config file
-- Install Ruby version `2.3.8` with Orb
+- Install Ruby version `2.6.3` with Orb
 - Build should be green if Ruby installed properly
 
 **Help:**


### PR DESCRIPTION
Support for Ruby version 2.3 has ended and it's now recommended to use 2.6

[Announcement from Ruby](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/)

Updated Ruby version to 2.6.3