### PR TITLE
fix(16 Reusable Config): make command names lowercase & hyphenated

### DIFF
--- a/16 Reusable config/.circleci/config.yml
+++ b/16 Reusable config/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 commands:
-  generatelogs:
+  generate-logs:
     description: "A command to generate a log file"
     parameters:
       path:
@@ -9,7 +9,7 @@ commands:
         default: "~/randomfolder"
     steps:
       - run: echo "Log file" > <<parameters.path>>/log.txt
-  endMission:
+  end-mission:
     description: "Use the parameters of this command to exit this mission with a green build."
     parameters:
       exitCode:
@@ -23,7 +23,7 @@ jobs:
     executor: custom-node
     steps:
       - run: echo "console.log('complete')" | node
-      - generatelogs
+      - generate-logs
       - run:
           name: Check for logs - DO NOT MODIFY
           command: |
@@ -31,9 +31,7 @@ jobs:
               echo "The log should exist at ~/project/log.txt after running the 'generatelogs' command"
               exit 1
             fi
-      - endMission
-
-
+      - end-mission
 
 workflows:
   version: 2


### PR DESCRIPTION
#### motivation

While trying to solve for this Koan (no. 16), I noted from CircleCI's build failure that command names cannot have uppercase letters.

Specifically, the error was:

```
[#/commands/endMission] string [endMission] does not match pattern ^[a-z][a-z\d_-]*$
```

Ref: https://app.circleci.com/pipelines/github/kelvintaywl/CircleCI-Training-Koans/46/workflows/93b5c3a3-cb35-408a-881a-4008e1e38a28/jobs/159?invite=true#step-101-23