### PR TITLE
Name key does not exist and orb version update

### DIFF
--- a/07 Test Summary/.circleci/config.yml
+++ b/07 Test Summary/.circleci/config.yml
@@ -1,13 +1,12 @@
 version: 2.1
 orbs:
-  build-tools: circleci/build-tools@2.2.0 # This is an orb. If you are not yet familiar with orbs, we will go over them soon. Orbs allow us to make our configs shorter by allowing us to "import" config in a similar way to a programming language's package manager.
+  build-tools: circleci/build-tools@3.0.0 # This is an orb. If you are not yet familiar with orbs, we will go over them soon. Orbs allow us to make our configs shorter by allowing us to "import" config in a similar way to a programming language's package manager.
 jobs:
   build:
     docker: 
       - image: circleci/node 
     steps:
       - build-tools/test-results:
-          name: Generating test results.
           data-dir: ~/project/results
           upload: true
 # Add below this line, do not modify above


### PR DESCRIPTION
"name" key does not exist in test-results step and produces config invalid errors. Verified key does not exist in the test-results section of build-tools documentation at orb registry.
Suggesting to update build-tools version to 3.0.0(latest) in case of any changes made to documentation
Reference:
https://circleci.com/developer/orbs/orb/circleci/build-tools?#commands-test-results
https://circleci.com/developer/orbs/orb/circleci/build-tools?#quick-start