### PR TITLE
Yarn dependency error

### DIFF
--- a/12 Matrix Builds/.circleci/config.yml
+++ b/12 Matrix Builds/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 executors:
   linux:
     docker:
-      - image: cimg/base:2020.01
+      - image: cimg/base:2021.10
   macos:
     macos:
-      xcode: 11.4
+      xcode: 12.5.1
 
 orbs:
-  node: circleci/node@2.0.0
+  node: circleci/node@4.7.0
 
 jobs:
   test:


### PR DESCRIPTION
Xcode version on this config file needs to be updated because of Yarn incompatible dependency error #60 when running matrix jobs on macOS machines 

Updating the Xcode version only will also successfully complete the matrix job on macOS but I suggest updating the rest of the components for long term training purpose 

Tested matrix job and passed successfully