### PR TITLE
Fix documentation links for koan 17

### DIFF
--- a/17 Executors/README.md
+++ b/17 Executors/README.md
@@ -17,8 +17,8 @@ What key aspects are important to note?
 <details>
   <summary>Spoiler warning</summary>
 
-https://circleci.com/docs/2.0/executor-types/
-https://circleci.com/docs/2.0/executor-types/#using-the-windows-executor
-https://circleci.com/docs/2.0/executor-types/#using-macos => note the first line in italics
+https://circleci.com/docs/executor-intro
+https://circleci.com/docs/executor-intro#windows
+https://circleci.com/docs/executor-intro#macos
 
 </details>


### PR DESCRIPTION
Updates the docs links in koan 17 to point to the new docs pages
(Page was redirecting, but the # heading links were incorrect)