### PR TITLE
add doc that shows test splitting UI

### DIFF
--- a/04 Parallelism/README.md
+++ b/04 Parallelism/README.md
@@ -14,5 +14,6 @@ Parallelism allows us to split a large workload, e.g a large number of tests, ac
   <summary>Spoiler warning</summary>
 
   * https://circleci.com/docs/2.0/parallelism-faster-jobs/#running-split-tests
+  * https://circleci.com/docs/test-splitting-tutorial/
   
 </details>


### PR DESCRIPTION
Adding a doc to 04 Parallelism to show what test splitting looks like in the UI. Previously the hint only showed how it looked in YAML