### PR TITLE
Update Orbs Koan to use Ruby 3.2.0 instead of 2.6.3 to resolve build issue

### DIFF
--- a/05 Orbs/.circleci/config.yml
+++ b/05 Orbs/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - image: cimg/base:2022.10
     steps:
       - checkout
-      # Add step below to install Ruby version 2.6.3
+      # Add step below to install Ruby version 3.2.0
 
       
       - run: ruby -v

--- a/05 Orbs/README.md
+++ b/05 Orbs/README.md
@@ -2,12 +2,12 @@
 
 **Description:**
 
-We have a config file that requires a specific Ruby version be installed, however the image we are using doesn't have Ruby, so the build fails. Utilizing the Ruby Orb (`circleci/ruby`) install Ruby version `2.6.3` so the build will be green.
+We have a config file that requires a specific Ruby version be installed, however the image we are using doesn't have Ruby, so the build fails. Utilizing the Ruby Orb (`circleci/ruby`) install Ruby version `3.2.0` so the build will be green.
 
 **Goals:**
 
 - Add the Ruby Orb to the config file
-- Install Ruby version `2.6.3` with Orb
+- Install Ruby version `3.2.0` with Orb
 - Build should be green if Ruby installed properly
 
 **Help:**


### PR DESCRIPTION
Ruby 2.6.3 does not build with cimg/base:2022.10 due to a compatibility issue with OpenSSL 3.0 vs 1.1.

Ubuntu 22.04 only provides OpenSSL 3.0, which is supported only by Ruby versions 3.1+.

Solution is to either use an older cimg/base or more reasonably a newer Ruby version.

Reference: https://github.com/rbenv/ruby-build/discussions/1940
Failed build: https://app.circleci.com/pipelines/github/denislemire/CI-ZenGarden/9/workflows/4b257561-73c2-4940-af46-a8bd2b0c277c/jobs/8